### PR TITLE
Explicitly naming column names in update to `_versions_links`

### DIFF
--- a/server/services/core-api.js
+++ b/server/services/core-api.js
@@ -72,7 +72,7 @@ module.exports = {
     });
     for (const version of data.versions) {
       await strapi.db.connection.raw(
-        `INSERT INTO ${model.collectionName}_versions_links VALUES (${version},${result.id})`
+        `INSERT INTO ${model.collectionName}_versions_links (${model.info.singularName}_id, inv_${model.info.singularName}_id) VALUES (${version},${result.id})`
       );
     }
     return result;


### PR DESCRIPTION
Fixes #45 with more explicit SQL

@martincapek does this look like better SQL and a small enough change to get merged in? Thank you