### PR TITLE
Resolve related table naming issues

### DIFF
--- a/server/services/core-api.js
+++ b/server/services/core-api.js
@@ -72,7 +72,7 @@ module.exports = {
     });
     for (const version of data.versions) {
       await strapi.db.connection.raw(
-        `INSERT INTO ${model.collectionName}_versions_links VALUES (${version},${result.id})`
+        `INSERT INTO ${_.snakeCase(model.collectionName)}_versions_links(${_.snakeCase(model.info.singularName)}_id, inv_${_.snakeCase(model.info.singularName)}_id) VALUES (${version},${result.id})`
       );
     }
     return result;


### PR DESCRIPTION
The SQL statement used by the current plugin is inconsistent with that in @strapi/database. This change fixes the naming problem.
Fixed: #51 
and contains
#46 #48 

For detailed associated code, please refer to : https://github.com/strapi/strapi/blob/main/packages/core/database/lib/metadata/relations.js

**createJoinTable**  function

@martincapek 