### PR TITLE
The engine "node" is incompatible with this module. Expected version ">=12.x.x <=16.x.x"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@strapi/strapi": "^4.6.0"
   },
   "engines": {
-    "node": ">=12.x.x <=16.x.x",
+    "node": ">=12.x.x <=18.x.x",
     "npm": ">=6.0.0"
   },
   "strapi": {


### PR DESCRIPTION
There is an error on `yarn install` 
`The engine "node" is incompatible with this module. Expected version ">=12.x.x <=16.x.x". Got "18.13.0"`

However, according to Strapi docs Node v18.x is recommended for Strapi v4.3.9 and above