### PR TITLE
🔨 [hcarp] Fixed Version Switch Type Not Matching

### DIFF
--- a/admin/src/components/Versions/index.js
+++ b/admin/src/components/Versions/index.js
@@ -98,7 +98,7 @@ const Versions = () => {
       }
 
       // fixed bug when version being iterated was not the same type as the version being selected (string != number)
-      const selectedVersion = data.find((v) => v.versionNumber === +value);
+      const selectedVersion = data.find((v) => v.versionNumber === Number(value));
 
       push({
         search: location.search,

--- a/admin/src/components/Versions/index.js
+++ b/admin/src/components/Versions/index.js
@@ -87,7 +87,8 @@ const Versions = () => {
         return;
       }
 
-      const selectedVersion = data.find((v) => v.versionNumber === value);
+      // fixed bug when version being iterated was not the same type as the version being selected (string != number)
+      const selectedVersion = data.find((v) => v.versionNumber === +value);
 
       push({
         search: location.search,

--- a/package.json
+++ b/package.json
@@ -9,14 +9,12 @@
     "Martin Čapek <martin.capek@notum.cz> (https://notum.cz/en/strapi)"
   ],
   "dependencies": {
-    "@strapi/design-system": "^1.8.0",
-    "@strapi/icons": "^1.8.0",
-    "@strapi/utils": "^4.11.1",
+    "@strapi/utils": "^4.6.0",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^4.11.1"
+    "@strapi/strapi": "^4.6.0"
   },
   "engines": {
     "node": ">=12.x.x <=18.x.x",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "Martin Čapek <martin.capek@notum.cz> (https://notum.cz/en/strapi)"
   ],
   "dependencies": {
-    "@strapi/utils": "^4.6.0",
+    "@strapi/design-system": "^1.8.0",
+    "@strapi/icons": "^1.8.0",
+    "@strapi/utils": "^4.11.1",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@strapi/strapi": "^4.6.0"
+    "@strapi/strapi": "^4.11.1"
   },
   "engines": {
     "node": ">=12.x.x <=18.x.x",


### PR DESCRIPTION
Fixed a bug where the type of the version being selected was not the same as the version in the Find() loop in the callback function.
This resulted in the version not being found and an uncaught exception being thrown.