### PR TITLE
fix(relations): many to many misconnection

### DIFF
--- a/server/services/content-types.js
+++ b/server/services/content-types.js
@@ -154,7 +154,6 @@ const manageRelations = async (newData, uid, oldVersionId, model) => {
     populate: updatableRelations,
   });
   const connects = {};
-  console.log(updatableRelations);
   updatableRelations.forEach((rel) => {
     const prevRel = previousVersion[rel];
     if (prevRel) {


### PR DESCRIPTION
For many to many relations relations from older versions of the content were reassigned. This PR fixes it by updating only many-to-many relations that are still present on the updated entry.

Closes #148 