### PR TITLE
fix: Update relations mapping to support dynamic zones

### DIFF
--- a/server/middlewares/relationUpdate.js
+++ b/server/middlewares/relationUpdate.js
@@ -12,6 +12,7 @@ const _ = require("lodash");
 const relationUpdateMiddleware = async (ctx, next) => {
   const { model, id } = ctx.request.params;
   const modelDef = strapi.getModel(model);
+
   if (
     !getService("content-types").isVersionedContentType(modelDef) ||
     modelDef.__schema__.kind === "singleType"
@@ -22,12 +23,14 @@ const relationUpdateMiddleware = async (ctx, next) => {
   const entry = await strapi.entityService.findOne(model, id, {
     populate: "*",
   });
+
   const allVersionIds = await strapi.db.query(model).findMany({
     select: ["id"],
     where: {
       vuid: entry.vuid,
     },
   });
+
   const allVersionIdsNumbers = allVersionIds.map((id) => id.id);
   if (allVersionIdsNumbers.length < 2) {
     // there are no multiple version, no need to update relations

--- a/server/register.js
+++ b/server/register.js
@@ -97,4 +97,15 @@ const addStrapiVersioningMiddleware = (strapi) => {
       return next();
     }
   );
+
+  strapi.server.router.use(
+    "/content-manager/collection-types/:model/:id",
+    (ctx, next) => {
+      if (ctx.method === "PUT") {
+        return relationUpdateMiddleware(ctx, next);
+      }
+
+      return next();
+    }
+  );
 };


### PR DESCRIPTION
Fixes #132 

Using a recursive function, iterates through all the dynamic zones on a model and finds the components that are relations then, builds up the connections using the new and existing data for each component.

The change to server/register.js was to enable draft pages to have their references updated without publishing. Something that I believe @omikulcik was investigating