### PR TITLE
fix: do not show currently showed version when initial data is empty

### DIFF
--- a/admin/src/components/Versions/index.js
+++ b/admin/src/components/Versions/index.js
@@ -174,7 +174,7 @@ const Versions = () => {
             </div>
           </div>
         )}
-        {!isCreatingEntry && (
+        {!isCreatingEntry && !!Object.keys(initialData || {}).length && (
           <div style={{ marginBottom: 20 }}>
             <Typography fontWeight="bold">
               {formatMessage({


### PR DESCRIPTION
Fixes #177.

I have found that due to [this commit](https://github.com/strapi/strapi/commit/687ad7e959d10f5a592bf06e35f86bb6d6e61051#diff-bc38394181e14114c137b4ea2679c65c9f11992b5293c665b3ad7507ef9d58c2) of strapi before v4.17.1, `isCreatingEntry` will no longer be set as true for single type content manager even when there is no record for that type and `initialData` is an empty object.